### PR TITLE
fix(tui): clipboard image paste on WSL via WSLg and alternative keybinds

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -248,6 +248,30 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
+        title: "Paste image from clipboard",
+        description: "Read image data directly from clipboard (use when Ctrl+V doesn't work)",
+        value: "prompt.paste_image",
+        keybind: "input_paste_image",
+        category: "Prompt",
+        slash: {
+          name: "image",
+          aliases: ["paste-image"],
+        },
+        onSelect: async () => {
+          const content = await Clipboard.read()
+          if (!content) return
+          if (content.mime.startsWith("image/")) {
+            await pasteImage({
+              filename: "clipboard",
+              mime: content.mime,
+              content: content.data,
+            })
+          } else if (content.mime === "text/plain" && content.data) {
+            input.insertText(content.data)
+          }
+        },
+      },
+      {
         title: "Interrupt session",
         value: "session.interrupt",
         keybind: "session_interrupt",
@@ -943,7 +967,6 @@ export function Prompt(props: PromptProps) {
                     })
                     return
                   }
-                  // If no image, let the default paste behavior continue
                 }
                 if (keybind.match("input_clear", e) && store.prompt.input !== "") {
                   input.clear()

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -9,7 +9,23 @@ import { Filesystem } from "../../../../util/filesystem"
 
 const isWSL = platform() === "linux" && /wsl|microsoft/i.test(release())
 
-// WSLg Wayland socket lives at /mnt/wslg/runtime-dir, not XDG_RUNTIME_DIR
+async function convertBmpToPng(bmpData: Buffer): Promise<Buffer | undefined> {
+  const converter = Bun.which("ffmpeg") ? ["ffmpeg", "-hide_banner", "-loglevel", "error", "-i", "pipe:0", "-f", "image2pipe", "-c:v", "png", "pipe:1"]
+    : Bun.which("magick") ? ["magick", "bmp:-", "png:-"]
+    : Bun.which("convert") ? ["convert", "bmp:-", "png:-"]
+    : undefined
+  if (!converter) return undefined
+  try {
+    const proc = Bun.spawn(converter, { stdin: "pipe", stdout: "pipe", stderr: "ignore" })
+    proc.stdin.write(bmpData)
+    proc.stdin.end()
+    const output = await new Response(proc.stdout).arrayBuffer()
+    await proc.exited
+    if (output.byteLength > 0) return Buffer.from(output)
+  } catch {}
+  return undefined
+}
+
 function wslgRuntimeDir(): string | undefined {
   if (!isWSL) return undefined
   const wslgDir = "/mnt/wslg/runtime-dir"
@@ -68,7 +84,8 @@ export namespace Clipboard {
     }
 
     if (os === "linux") {
-      const mimePriority = ["image/png", "image/jpeg", "image/webp", "image/gif", "image/bmp"]
+      const apiMimes = ["image/png", "image/jpeg", "image/webp", "image/gif"]
+      const mimePriority = [...apiMimes, "image/bmp"]
       const wlPasteAvailable = process.env["WAYLAND_DISPLAY"] && Bun.which("wl-paste")
       if (wlPasteAvailable) {
         const runtimeDir = wslgRuntimeDir()
@@ -83,6 +100,11 @@ export namespace Clipboard {
             if (available.includes(mime)) {
               const data = await $`wl-paste -t ${mime}`.env(wlEnv).nothrow().quiet().arrayBuffer()
               if (data && data.byteLength > 0) {
+                if (mime === "image/bmp") {
+                  const converted = await convertBmpToPng(Buffer.from(data))
+                  if (converted) return { data: converted.toString("base64"), mime: "image/png" }
+                  continue
+                }
                 return { data: Buffer.from(data).toString("base64"), mime }
               }
             }
@@ -99,6 +121,11 @@ export namespace Clipboard {
             if (available.includes(mime)) {
               const data = await $`xclip -selection clipboard -t ${mime} -o`.nothrow().quiet().arrayBuffer()
               if (data && data.byteLength > 0) {
+                if (mime === "image/bmp") {
+                  const converted = await convertBmpToPng(Buffer.from(data))
+                  if (converted) return { data: converted.toString("base64"), mime: "image/png" }
+                  continue
+                }
                 return { data: Buffer.from(data).toString("base64"), mime }
               }
             }

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -4,7 +4,18 @@ import clipboardy from "clipboardy"
 import { lazy } from "../../../../util/lazy.js"
 import { tmpdir } from "os"
 import path from "path"
+import { existsSync } from "fs"
 import { Filesystem } from "../../../../util/filesystem"
+
+const isWSL = platform() === "linux" && /wsl|microsoft/i.test(release())
+
+// WSLg Wayland socket lives at /mnt/wslg/runtime-dir, not XDG_RUNTIME_DIR
+function wslgRuntimeDir(): string | undefined {
+  if (!isWSL) return undefined
+  const wslgDir = "/mnt/wslg/runtime-dir"
+  if (existsSync(wslgDir + "/wayland-0")) return wslgDir
+  return undefined
+}
 
 /**
  * Writes text to clipboard via OSC 52 escape sequence.
@@ -43,7 +54,8 @@ export namespace Clipboard {
       }
     }
 
-    if (os === "win32" || release().includes("WSL")) {
+    // PowerShell clipboard: only on native Windows (on WSL, processes can't access the Windows clipboard session)
+    if (os === "win32") {
       const script =
         "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $ms = New-Object System.IO.MemoryStream; $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray()) }"
       const base64 = await $`powershell.exe -NonInteractive -NoProfile -command "${script}"`.nothrow().text()
@@ -57,8 +69,11 @@ export namespace Clipboard {
 
     if (os === "linux") {
       const mimePriority = ["image/png", "image/jpeg", "image/webp", "image/gif", "image/bmp"]
-      if (process.env["WAYLAND_DISPLAY"] && Bun.which("wl-paste")) {
-        const types = await $`wl-paste --list-types`.nothrow().quiet().text()
+      const wlPasteAvailable = process.env["WAYLAND_DISPLAY"] && Bun.which("wl-paste")
+      if (wlPasteAvailable) {
+        const runtimeDir = wslgRuntimeDir()
+        const wlEnv = runtimeDir ? { ...process.env, XDG_RUNTIME_DIR: runtimeDir } : process.env
+        const types = await $`wl-paste --list-types`.env(wlEnv).nothrow().quiet().text()
         if (types) {
           const available = types
             .split("\n")
@@ -66,7 +81,7 @@ export namespace Clipboard {
             .filter(Boolean)
           for (const mime of mimePriority) {
             if (available.includes(mime)) {
-              const data = await $`wl-paste -t ${mime}`.nothrow().quiet().arrayBuffer()
+              const data = await $`wl-paste -t ${mime}`.env(wlEnv).nothrow().quiet().arrayBuffer()
               if (data && data.byteLength > 0) {
                 return { data: Buffer.from(data).toString("base64"), mime }
               }
@@ -112,8 +127,10 @@ export namespace Clipboard {
     if (os === "linux") {
       if (process.env["WAYLAND_DISPLAY"] && Bun.which("wl-copy")) {
         console.log("clipboard: using wl-copy")
+        const runtimeDir = wslgRuntimeDir()
+        const env = runtimeDir ? { ...process.env, XDG_RUNTIME_DIR: runtimeDir } : undefined
         return async (text: string) => {
-          const proc = Bun.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
+          const proc = Bun.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "ignore", env })
           proc.stdin.write(text)
           proc.stdin.end()
           await proc.exited.catch(() => {})

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -835,6 +835,11 @@ export namespace Config {
       variant_cycle: z.string().optional().default("ctrl+t").describe("Cycle model variants"),
       input_clear: z.string().optional().default("ctrl+c").describe("Clear input field"),
       input_paste: z.string().optional().default("ctrl+v").describe("Paste from clipboard"),
+      input_paste_image: z
+        .string()
+        .optional()
+        .default("ctrl+alt+v")
+        .describe("Paste image from clipboard (useful on WSL where Ctrl+V may be intercepted)"),
       input_submit: z.string().optional().default("return").describe("Submit input"),
       input_newline: z
         .string()

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -939,6 +939,10 @@ export type KeybindsConfig = {
    */
   input_paste?: string
   /**
+   * Paste image from clipboard (useful on WSL where Ctrl+V may be intercepted)
+   */
+  input_paste_image?: string
+  /**
    * Submit input
    */
   input_submit?: string

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1237,6 +1237,10 @@ export type KeybindsConfig = {
    */
   input_paste?: string
   /**
+   * Paste image from clipboard (useful on WSL where Ctrl+V may be intercepted)
+   */
+  input_paste_image?: string
+  /**
    * Submit input
    */
   input_submit?: string


### PR DESCRIPTION
## Summary

Fixes #2 — Clipboard image paste doesn't work on WSL (Windows Terminal intercepts Ctrl+V).

### Commits

1. **fix(tui): fix clipboard image paste on WSL via WSLg Wayland bridge**
   - Skips PowerShell clipboard on WSL (can't access Windows clipboard session)
   - Fixes `wl-paste`/`wl-copy` to use `XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir` (WSLg socket location)

2. **fix(tui): convert BMP clipboard images to PNG for API compatibility**
   - Windows clipboard stores screenshots as BMP, which LLM APIs reject
   - Auto-converts BMP → PNG using ffmpeg, ImageMagick `magick`, or `convert`
   - Only triggers when clipboard offers BMP and no other supported format

3. **feat(tui): add Ctrl+Alt+V keybind and /image command for clipboard image paste**
   - Windows Terminal intercepts Ctrl+V before it reaches terminal apps; Ctrl+Alt+V passes through (confirmed via raw stdin testing)
   - Adds `input_paste_image` keybind (default: `Ctrl+Alt+V`)
   - Adds `/image` slash command (alias: `/paste-image`)
   - Adds "Paste image from clipboard" in command palette (`Ctrl+P`)
   - All existing `Ctrl+V` behavior is unchanged

### Why Ctrl+V can't work directly

Windows Terminal intercepts `Ctrl+V` at the emulator level. When clipboard has text, WT sends it as bracketed paste. When clipboard has only an image, WT sends nothing — zero bytes reach stdin. WT doesn't implement the Kitty keyboard protocol, so there's no way to receive the raw keypress. `Ctrl+Alt+V` is confirmed to pass through WT.

## Testing

1. Run OpenCode in WSL2 via Windows Terminal
2. Copy an image (e.g., Win+Shift+S screenshot)
3. Press `Ctrl+Alt+V` — image should be pasted
4. Or type `/image` — same result
5. Or `Ctrl+P` → "Paste image from clipboard" — same result
6. Regular `Ctrl+V` text paste is unchanged